### PR TITLE
Added missing event parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# GregoriousTick (Minecraft Forge 1.7.10)
+# GregoriousTick Fork (Minecraft Forge 1.7.10)
+A quick fork that fixes the following error on start up
+[07:18:10] [Server thread/ERROR] [GregoriousTickMod]: The mod GregoriousTickMod appears to have an invalid event annotation EventHandler. This annotation can only apply to methods with recognized event arguments - it will not be called
+
+This fork adds the missing parameter to the init EventHandler.
 
 ## Description
 GregoriousTick is a Minecraft mod designed for Minecraft version 1.7.10. It provides functionality to control the daylight cycle in the game based on player activity. When the last player logs out of the server, the mod stops the daylight cycle. When a player logs in, the daylight cycle is resumed.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-# GregoriousTick Fork (Minecraft Forge 1.7.10)
-A quick fork that fixes the following error on start up
-[07:18:10] [Server thread/ERROR] [GregoriousTickMod]: The mod GregoriousTickMod appears to have an invalid event annotation EventHandler. This annotation can only apply to methods with recognized event arguments - it will not be called
-
-This fork adds the missing parameter to the init EventHandler.
+# GregoriousTick (Minecraft Forge 1.7.10)
 
 ## Description
 GregoriousTick is a Minecraft mod designed for Minecraft version 1.7.10. It provides functionality to control the daylight cycle in the game based on player activity. When the last player logs out of the server, the mod stops the daylight cycle. When a player logs in, the daylight cycle is resumed.

--- a/src/main/java/com/integral/gregorioustick/GregoriousTick.java
+++ b/src/main/java/com/integral/gregorioustick/GregoriousTick.java
@@ -5,6 +5,7 @@ import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerLoggedOutEvent;
+import cpw.mods.fml.common.event.*;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.MinecraftForge;
@@ -19,7 +20,7 @@ public class GregoriousTick {
     private static final Logger LOGGER = LogManager.getLogger("GregoriousTick");
 
     @Mod.EventHandler
-    public void init() {
+    public void init(FMLInitializationEvent event) {
         MinecraftForge.EVENT_BUS.register(this);
         FMLCommonHandler.instance().bus().register(this);
         LOGGER.info("GregoriousTick has been initialized.");


### PR DESCRIPTION
Fixes below startup error on server.

[07:18:10] [Server thread/ERROR] [GregoriousTickMod]: The mod GregoriousTickMod appears to have an invalid event annotation EventHandler. This annotation can only apply to methods with recognized event arguments - it will not be called